### PR TITLE
Fix fontspec error: "font-not-found"

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -8,8 +8,6 @@
 % Requirements to use.
 \usepackage{fontspec}
 
-% Define shortcut to load the Font Awesome font.
-\newfontfamily{\FA}{FontAwesome}
 % Generic command displaying an icon by its name.
 \newcommand*{\faicon}[1]{{
   \FA\csname faicon@#1\endcsname


### PR DESCRIPTION
The \FA font family is declared both in fontawesome.sty (without a path)
and in awesome-cv.cls (with a path). This confuses xelatex and produces
a font-not-found error if Font Awesome is not installed globally. It is
fixed by only using the declaration with a path.

This closes #181 and #221.